### PR TITLE
Update libv8 to allow installation on El Capitan

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
-    libv8 (3.16.14.7)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     loofah-activerecord (1.2.0)
@@ -274,3 +274,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   warden
   will_paginate
+
+BUNDLED WITH
+   1.12.5


### PR DESCRIPTION
libv8 fails to compile in El Capitan. This issue was resolved at https://github.com/cowboyd/libv8/pull/177 and so this was easily fixed by updating libv8.
